### PR TITLE
feat: implement syntax highlighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .mypy_cache/
 __pycache__/
 dist/
-dev/
+x.py

--- a/dbglib/main.py
+++ b/dbglib/main.py
@@ -126,3 +126,5 @@ def dbg(structure: Any) -> None:
             )
 
             break
+
+    return structure

--- a/dbglib/main.py
+++ b/dbglib/main.py
@@ -47,13 +47,15 @@ def syntax_highlight(structure, structure_type):
         bool_color = GREEN if structure else RED
         return f"{ITALIC}{bool_color}{structure}{RESET}"
     elif structure_type in {"list", "set", "tuple", "str"}:
-        new = []
-        for element in structure:
-            new.append(syntax_highlight(element, get_structure_type(element)))
+        # Implement recursive syntax highlighting for lists
+        list_with_syntax_highlight = [
+            syntax_highlight(element, get_structure_type(element))
+            for element in structure
+        ]
 
-        return f"{RESET}[{RESET}{', '.join(new)}]{RESET}"
+        return f"{RESET}[{RESET}{', '.join(list_with_syntax_highlight)}]{RESET}"
 
-    return f"{BLUE}{str(structure)}{RESET}"
+    return f"{CYAN}{str(structure)}{RESET}"
 
 
 def dbg(structure: Any) -> None:

--- a/dbglib/main.py
+++ b/dbglib/main.py
@@ -39,6 +39,8 @@ def get_structure_type(structure):
 
 
 def syntax_highlight(structure, structure_type):
+    # Uses recursive syntax highlighting for lists and dicts
+
     if structure_type == "int":
         return f"{YELLOW}{structure:,}{RESET}"
     elif structure_type == "str":
@@ -46,14 +48,16 @@ def syntax_highlight(structure, structure_type):
     elif structure_type == "bool":
         bool_color = GREEN if structure else RED
         return f"{ITALIC}{bool_color}{structure}{RESET}"
-    elif structure_type in {"list", "set", "tuple", "str"}:
-        # Implement recursive syntax highlighting for lists
+    elif structure_type in {"list", "set", "tuple"}:
         list_with_syntax_highlight = [
             syntax_highlight(element, get_structure_type(element))
             for element in structure
         ]
 
-        return f"{BOLD}[{RESET}{', '.join(list_with_syntax_highlight)}{BOLD}]{RESET}"
+        brackets = {"list": "[]", "set": "{}", "tuple": "()"}
+        open_bracket, close_bracket = brackets[structure_type]  # string unpacking
+
+        return f"{BOLD}{open_bracket}{RESET}{', '.join(list_with_syntax_highlight)}{BOLD}{close_bracket}{RESET}"
     elif structure_type == "dict":
         dict_with_syntax_highlight = {
             syntax_highlight(k, get_structure_type(k)): syntax_highlight(
@@ -66,7 +70,7 @@ def syntax_highlight(structure, structure_type):
             f"{k}: {v}" for k, v in dict_with_syntax_highlight.items()
         )
 
-        open_curly, close_curly = "{", "}"  # f-string limitations
+        open_curly, close_curly = "{}"  # string unpacking because f-string limitations
 
         return f"{BOLD}{open_curly}{RESET}{joined_dict}{BOLD}{close_curly}{RESET}"
 

--- a/dbglib/main.py
+++ b/dbglib/main.py
@@ -53,7 +53,22 @@ def syntax_highlight(structure, structure_type):
             for element in structure
         ]
 
-        return f"{RESET}[{RESET}{', '.join(list_with_syntax_highlight)}]{RESET}"
+        return f"{BOLD}[{RESET}{', '.join(list_with_syntax_highlight)}{BOLD}]{RESET}"
+    elif structure_type == "dict":
+        dict_with_syntax_highlight = {
+            syntax_highlight(k, get_structure_type(k)): syntax_highlight(
+                v, get_structure_type(v)
+            )
+            for k, v in structure.items()
+        }
+
+        joined_dict = ", ".join(
+            f"{k}: {v}" for k, v in dict_with_syntax_highlight.items()
+        )
+
+        open_curly, close_curly = "{", "}"  # f-string limitations
+
+        return f"{BOLD}{open_curly}{RESET}{joined_dict}{BOLD}{close_curly}{RESET}"
 
     return f"{CYAN}{str(structure)}{RESET}"
 
@@ -91,7 +106,7 @@ def dbg(structure: Any) -> None:
             # special modifiers for certain types
             extras = ""
 
-            if structure_type in {"list", "set", "tuple", "str"}:
+            if structure_type in {"dict", "list", "set", "tuple", "str"}:
                 structure_len = len(structure)
                 extras += f", len={structure_len}"
 

--- a/dbglib/main.py
+++ b/dbglib/main.py
@@ -32,6 +32,30 @@ print(
 )
 
 
+def get_structure_type(structure):
+    structure_type = str(type(structure))
+    # do some regex substitution to get a clear type representation
+    return re.sub(r"<class '(.*)'>", r"\1", structure_type)
+
+
+def syntax_highlight(structure, structure_type):
+    if structure_type == "int":
+        return f"{YELLOW}{structure:,}{RESET}"
+    elif structure_type == "str":
+        return f"{GREEN}'{structure}'{RESET}"
+    elif structure_type == "bool":
+        bool_color = GREEN if structure else RED
+        return f"{ITALIC}{bool_color}{structure}{RESET}"
+    elif structure_type in {"list", "set", "tuple", "str"}:
+        new = []
+        for element in structure:
+            new.append(syntax_highlight(element, get_structure_type(element)))
+
+        return f"{RESET}[{RESET}{', '.join(new)}]{RESET}"
+
+    return f"{BLUE}{str(structure)}{RESET}"
+
+
 def dbg(structure: Any) -> None:
     stack = inspect.stack()
 
@@ -59,20 +83,14 @@ def dbg(structure: Any) -> None:
             basename = Path(filename).name
             line_number = frame.lineno
             structure_input = line[start:end]
-            structure_value = structure
-
-            structure_type = str(type(structure))
-
-            # do some regex substitution to get a clear type representation
-            structure_type = re.sub(r"<class '(.*)'>", r"\1", structure_type)
-
-            extras = ""
+            structure_type = get_structure_type(structure)
+            structure_value = syntax_highlight(structure, structure_type)
 
             # special modifiers for certain types
-            if structure_type == "int":
-                structure_value = f"{structure_value:,}"  # auto comma delimiters
-            elif structure_type in {"list", "set", "tuple", "str"}:
-                structure_len = len(structure_value)
+            extras = ""
+
+            if structure_type in {"list", "set", "tuple", "str"}:
+                structure_len = len(structure)
                 extras += f", len={structure_len}"
 
             # getting where the dbg function was called is a bit harder
@@ -83,7 +101,7 @@ def dbg(structure: Any) -> None:
             in_function = calframe[1][3]
 
             print(
-                f"{BLACK_ON_YELLOW} dbg {RESET} {BLUE}{basename}:{DIM}{line_number}{RESET} {DIM}({in_function}){RESET} {YELLOW}{DIM}->{RESET} {GREEN}{structure_input} {DIM}={RESET} {CYAN}{structure_value} {MAGENTA}({structure_type}{extras}){RESET}"
+                f"{BLACK_ON_YELLOW} dbg {RESET} {BLUE}{basename}:{DIM}{line_number}{RESET} {DIM}({in_function}){RESET} {YELLOW}{DIM}->{RESET} {structure_input} {DIM}={RESET} {structure_value} {MAGENTA}({structure_type}{extras}){RESET}"
             )
 
             break


### PR DESCRIPTION
This PR consists of the following changes:

- Implement syntax highlighting for the `dbg(...)` function
	- ints are yellow, strings are green, bools are italic and green or red, depending whether their value is True or False
	- Everything else is cyan
	- Syntax highlighting is recursive for lists, sets, tuples and dicts, so that everything can be highlighted correctly, no matter the level of nesting

- Allow the `dbg(...)` function to return a value. This would allow it to be used inside expressions like so:

```py
m = 100
if dbg(m > 50):
    return m
```
This will print out the dbg result of `m`, while also acting as a boolean expression


