### PR TITLE
Dynamically check for len method

### DIFF
--- a/dbglib/main.py
+++ b/dbglib/main.py
@@ -110,7 +110,7 @@ def dbg(structure: Any) -> Any:
             # special modifiers for certain types
             extras = ""
 
-            if structure_type in {"dict", "list", "set", "tuple", "str"}:
+            if hasattr(structure, "__len__"):
                 structure_len = len(structure)
                 extras += f", len={structure_len}"
 


### PR DESCRIPTION
Python uses the method `__len__` to get an object's length. We can dynamically check for that method with `hasattr` to support any object with a length.